### PR TITLE
XIA-1: complete Postdog request and response handling

### DIFF
--- a/src/api/postdog/index.js
+++ b/src/api/postdog/index.js
@@ -76,13 +76,27 @@ export function normalizeRequest(request) {
     headers: Array.isArray(request.headers) ? request.headers.map(normalizeKeyValue).filter(Boolean) : [],
     query: Array.isArray(request.query) ? request.query.map(normalizeKeyValue).filter(Boolean) : [],
     body: {
-      type: ["none", "json", "text"].includes(request.body?.type) ? request.body.type : "none",
-      text: String(request.body?.text ?? "")
+      type: ["none", "json", "text", "form", "multipart"].includes(request.body?.type) ? request.body.type : "none",
+      text: String(request.body?.text ?? ""),
+      fields: Array.isArray(request.body?.fields) ? request.body.fields.map(normalizeBodyField).filter(Boolean) : []
     },
     preScript: String(request.preScript || ""),
     postScript: String(request.postScript || ""),
     createdAt,
     updatedAt: Number(request.updatedAt) || createdAt
+  };
+}
+
+export function normalizeBodyField(item) {
+  const normalized = normalizeKeyValue(item);
+  if (!normalized) return null;
+  const kind = item.kind === "file" ? "file" : "text";
+  return {
+    ...normalized,
+    kind,
+    fileName: kind === "file" ? String(item.fileName || "file") : "",
+    mimeType: kind === "file" ? String(item.mimeType || "application/octet-stream") : "",
+    dataBase64: kind === "file" ? String(item.dataBase64 || "") : ""
   };
 }
 

--- a/src/api/postdog/index.test.js
+++ b/src/api/postdog/index.test.js
@@ -3,6 +3,7 @@ import { getChromeStorageSnapshot } from "../../../test/setup";
 import {
   POSTDOG_REQUESTS_KEY,
   deletePostdogFolder,
+  normalizeRequest,
   savePostdogFolder,
   savePostdogRequest
 } from "./index";
@@ -24,5 +25,28 @@ describe("postdog storage", () => {
     expect(snapshot[POSTDOG_REQUESTS_KEY]).toEqual([
       expect.objectContaining({ id: "req-loose", folderId: null })
     ]);
+  });
+
+  it("normalizes form and multipart fields", () => {
+    const request = normalizeRequest({
+      id: "req-fields",
+      name: "fields",
+      body: {
+        type: "multipart",
+        fields: [
+          { key: "title", value: "hello" },
+          { key: "upload", kind: "file", fileName: "a.txt", mimeType: "text/plain", dataBase64: "YQ==" }
+        ]
+      }
+    });
+
+    expect(request.body).toEqual({
+      type: "multipart",
+      text: "",
+      fields: [
+        expect.objectContaining({ key: "title", kind: "text", value: "hello" }),
+        expect.objectContaining({ key: "upload", kind: "file", fileName: "a.txt", dataBase64: "YQ==" })
+      ]
+    });
   });
 });

--- a/src/api/postdog/runtime.js
+++ b/src/api/postdog/runtime.js
@@ -117,7 +117,7 @@ export async function runPostdogRequest(input = {}) {
       method: prepared.method,
       url: prepared.url,
       headers: prepared.headers,
-      body: prepared.body || ""
+      body: formatRequestBodySnapshot(mutableRequest, prepared.body, envVars)
     }, secretValues),
     response: redactSecrets(responsePayload, secretValues),
     durationMs,
@@ -223,6 +223,21 @@ function prepareRequest(request, vars) {
     }
   }
   return { method, url, headers, body };
+}
+
+function formatRequestBodySnapshot(request, preparedBody, vars) {
+  if (request.body?.type !== "multipart") return preparedBody || "";
+  const lines = [];
+  for (const item of request.body.fields || []) {
+    if (item.enabled === false || !item.key) continue;
+    if (item.kind === "file") {
+      const sizeBytes = base64ToBytes(item.dataBase64 || "").byteLength;
+      lines.push(`${applyVariables(item.key, vars)}: [file ${applyVariables(item.fileName || "file", vars)}, ${item.mimeType || "application/octet-stream"}, ${sizeBytes} bytes]`);
+    } else {
+      lines.push(`${applyVariables(item.key, vars)}: ${applyVariables(item.value, vars)}`);
+    }
+  }
+  return lines.join("\n");
 }
 
 function removeHeader(headers, name) {

--- a/src/api/postdog/runtime.js
+++ b/src/api/postdog/runtime.js
@@ -15,6 +15,7 @@ const BODY_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const MAX_TEXT_RESPONSE_BYTES = 1024 * 1024;
 const MAX_STREAM_PREVIEW_BYTES = 64 * 1024;
 const STREAM_READ_TIMEOUT_MS = 5000;
+const MAX_DOWNLOAD_RESPONSE_BYTES = 25 * 1024 * 1024;
 
 export async function runPostdogRequest(input = {}) {
   const stored = input.id ? await getPostdogRequest(input.id) : null;
@@ -69,7 +70,8 @@ export async function runPostdogRequest(input = {}) {
       bodyJson: body.json,
       bodySizeBytes: body.sizeBytes,
       bodyTruncated: body.truncated,
-      bodyNote: body.note
+      bodyNote: body.note,
+      download: body.download
     };
   } catch (error) {
     responsePayload = {
@@ -123,6 +125,8 @@ export async function runPostdogRequest(input = {}) {
     logs: redactSecrets(scriptState.logs, secretValues)
   };
 
+  const historyResponse = { ...result.response };
+  delete historyResponse.download;
   const historyRun = await appendPostdogHistory({
     runId,
     createdAt,
@@ -134,7 +138,7 @@ export async function runPostdogRequest(input = {}) {
     ok: responsePayload.ok,
     durationMs,
     request: result.request,
-    response: result.response,
+    response: historyResponse,
     tests: result.tests,
     logs: result.logs
   });
@@ -186,6 +190,32 @@ function prepareRequest(request, vars) {
   }
   let body;
   if (BODY_METHODS.has(method) && request.body?.type !== "none") {
+    if (request.body?.type === "form") {
+      const params = new URLSearchParams();
+      for (const item of request.body.fields || []) {
+        if (item.enabled === false || !item.key) continue;
+        params.append(applyVariables(item.key, vars), applyVariables(item.value, vars));
+      }
+      body = params.toString();
+      if (!hasHeader(headers, "content-type")) headers["Content-Type"] = "application/x-www-form-urlencoded";
+      return { method, url, headers, body };
+    }
+    if (request.body?.type === "multipart") {
+      const form = new FormData();
+      for (const item of request.body.fields || []) {
+        if (item.enabled === false || !item.key) continue;
+        const key = applyVariables(item.key, vars);
+        if (item.kind === "file") {
+          const bytes = base64ToBytes(item.dataBase64 || "");
+          form.append(key, new Blob([bytes], { type: item.mimeType || "application/octet-stream" }), applyVariables(item.fileName || "file", vars));
+        } else {
+          form.append(key, applyVariables(item.value, vars));
+        }
+      }
+      body = form;
+      removeHeader(headers, "content-type");
+      return { method, url, headers, body };
+    }
     const rawBody = applyVariables(request.body?.text || "", vars);
     body = request.body?.type === "json" ? normalizeJsonRequestBody(rawBody) : rawBody;
     if (request.body?.type === "json" && !hasHeader(headers, "content-type")) {
@@ -193,6 +223,13 @@ function prepareRequest(request, vars) {
     }
   }
   return { method, url, headers, body };
+}
+
+function removeHeader(headers, name) {
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lower) delete headers[key];
+  }
 }
 
 function applyVariables(value, vars) {
@@ -232,13 +269,20 @@ async function readPostdogResponseBody(response) {
   const contentDisposition = response.headers.get("content-disposition") || "";
   const contentLength = parseContentLength(response.headers.get("content-length"));
   if (isBinaryResponse(contentType, contentDisposition)) {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const downloadable = bytes.byteLength <= MAX_DOWNLOAD_RESPONSE_BYTES;
     return {
       kind: "binary",
       text: "",
       json: null,
-      sizeBytes: contentLength,
+      sizeBytes: bytes.byteLength || contentLength,
       truncated: false,
-      note: "二进制响应未读取 body，仅保留状态、Header 和大小信息。"
+      note: downloadable ? "文件响应已就绪，可直接下载。" : "文件超过 25 MB，未保留下载内容。",
+      download: downloadable ? {
+        fileName: getDownloadFileName(contentDisposition, response.url, contentType),
+        mimeType: normalizeContentType(contentType) || "application/octet-stream",
+        dataBase64: bytesToBase64(bytes)
+      } : null
     };
   }
 
@@ -264,6 +308,38 @@ async function readPostdogResponseBody(response) {
       sizeBytes: result.sizeBytes
     })
   };
+}
+
+function getDownloadFileName(contentDisposition, responseUrl, contentType) {
+  const disposition = String(contentDisposition || "");
+  const utf8 = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8) {
+    try { return decodeURIComponent(utf8[1].replace(/^"|"$/g, "")); } catch { /* use fallback */ }
+  }
+  const plain = disposition.match(/filename\s*=\s*(?:"([^"]+)"|([^;]+))/i);
+  if (plain) return (plain[1] || plain[2]).trim();
+  try {
+    const name = new URL(responseUrl || "").pathname.split("/").filter(Boolean).pop();
+    if (name) return decodeURIComponent(name);
+  } catch { /* use fallback */ }
+  const extension = normalizeContentType(contentType).split("/")[1]?.replace(/[^a-z0-9.+-]/gi, "") || "bin";
+  return `download.${extension}`;
+}
+
+function bytesToBase64(bytes) {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(value) {
+  const binary = atob(String(value || ""));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
 }
 
 function isBinaryResponse(contentType, contentDisposition) {

--- a/src/api/postdog/runtime.test.js
+++ b/src/api/postdog/runtime.test.js
@@ -261,7 +261,14 @@ describe("postdog runtime", () => {
 
     vi.stubGlobal("fetch", vi.fn(async () => new Response(
       new Uint8Array([0x25, 0x50, 0x44, 0x46]),
-      { status: 200, headers: { "Content-Type": "application/pdf", "Content-Length": "4" } }
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/pdf",
+          "Content-Length": "4",
+          "Content-Disposition": "attachment; filename*=UTF-8''report%20final.pdf"
+        }
+      }
     )));
 
     const result = await runPostdogRequest({ id: request.id });
@@ -272,14 +279,86 @@ describe("postdog runtime", () => {
       bodyText: "",
       bodyJson: null,
       bodySizeBytes: 4,
-      bodyTruncated: false
+      bodyTruncated: false,
+      download: {
+        fileName: "report final.pdf",
+        mimeType: "application/pdf",
+        dataBase64: "JVBERg=="
+      }
     });
-    expect(result.response.bodyNote).toContain("二进制响应");
+    expect(result.response.bodyNote).toContain("文件响应已就绪");
     expect(snapshot[POSTDOG_HISTORY_KEY][0].response).toMatchObject({
       bodyKind: "binary",
       bodyText: "",
       bodyJson: null
     });
+    expect(snapshot[POSTDOG_HISTORY_KEY][0].response).not.toHaveProperty("download");
+  });
+
+  it("sends urlencoded form fields with variables and repeated keys", async () => {
+    await savePostdogEnvironment({
+      id: "env-form",
+      name: "form",
+      variables: [{ key: "item", value: "two words", enabled: true }]
+    });
+    await chrome.storage.local.set({ [POSTDOG_ACTIVE_ENVIRONMENT_KEY]: "env-form" });
+    const request = await savePostdogRequest({
+      id: "req-form",
+      name: "form",
+      method: "POST",
+      url: "https://api.example.com/form",
+      body: {
+        type: "form",
+        fields: [
+          { key: "tag", value: "one", enabled: true },
+          { key: "tag", value: "{{item}}", enabled: true },
+          { key: "skip", value: "no", enabled: false }
+        ]
+      }
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("{}", { status: 200 })));
+
+    await runPostdogRequest({ id: request.id });
+
+    const init = fetch.mock.calls[0][1];
+    expect(init.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+    expect(init.body).toBe("tag=one&tag=two+words");
+  });
+
+  it("sends multipart text and file fields without forcing a content-type boundary", async () => {
+    const request = await savePostdogRequest({
+      id: "req-multipart",
+      name: "upload",
+      method: "POST",
+      url: "https://api.example.com/upload",
+      headers: [{ key: "Content-Type", value: "multipart/form-data", enabled: true }],
+      body: {
+        type: "multipart",
+        fields: [
+          { key: "caption", value: "hello", kind: "text", enabled: true },
+          {
+            key: "file",
+            kind: "file",
+            fileName: "hello.txt",
+            mimeType: "text/plain",
+            dataBase64: "aGk=",
+            enabled: true
+          }
+        ]
+      }
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("{}", { status: 200 })));
+
+    await runPostdogRequest({ id: request.id });
+
+    const init = fetch.mock.calls[0][1];
+    expect(init.headers).not.toHaveProperty("Content-Type");
+    expect(init.body).toBeInstanceOf(FormData);
+    expect(init.body.get("caption")).toBe("hello");
+    const file = init.body.get("file");
+    expect(file.name).toBe("hello.txt");
+    expect(file.type).toBe("text/plain");
+    expect(await file.text()).toBe("hi");
   });
 
   it("stores a bounded preview for stream responses", async () => {

--- a/src/api/postdog/runtime.test.js
+++ b/src/api/postdog/runtime.test.js
@@ -359,6 +359,11 @@ describe("postdog runtime", () => {
     expect(file.name).toBe("hello.txt");
     expect(file.type).toBe("text/plain");
     expect(await file.text()).toBe("hi");
+    const snapshot = getChromeStorageSnapshot();
+    expect(snapshot[POSTDOG_HISTORY_KEY][0].request.body).toBe([
+      "caption: hello",
+      "file: [file hello.txt, text/plain, 2 bytes]"
+    ].join("\n"));
   });
 
   it("stores a bounded preview for stream responses", async () => {

--- a/src/component/postdog/PostdogPanel.jsx
+++ b/src/component/postdog/PostdogPanel.jsx
@@ -615,7 +615,7 @@ export default function PostdogPanel() {
                     <span>{response.request.url}</span>
                   </div>
                   {response.request.body ? (
-                    <pre>{response.request.body}</pre>
+                    <pre>{formatRequestBodyForDisplay(response.request.body)}</pre>
                   ) : (
                     <div className="postdog-empty-response">无 request body</div>
                   )}
@@ -860,6 +860,16 @@ function formatBinaryResponseMessage(response) {
   const contentType = response.headers?.["content-type"] || response.headers?.["Content-Type"] || "unknown";
   const size = formatResponseBytes(response.bodySizeBytes);
   return `${response.bodyNote || "二进制响应未展示。"} Content-Type: ${contentType}; Size: ${size}`;
+}
+
+function formatRequestBodyForDisplay(body) {
+  if (typeof body === "string") return body;
+  if (body == null) return "";
+  try {
+    return JSON.stringify(body, null, 2);
+  } catch {
+    return String(body);
+  }
 }
 
 function formatResponseBytes(bytes) {

--- a/src/component/postdog/PostdogPanel.jsx
+++ b/src/component/postdog/PostdogPanel.jsx
@@ -21,7 +21,7 @@ const EMPTY_REQUEST = {
   folderId: null,
   headers: [],
   query: [],
-  body: { type: "none", text: "" },
+  body: { type: "none", text: "", fields: [] },
   preScript: "",
   postScript: ""
 };
@@ -29,6 +29,7 @@ const SIDEBAR_WIDTH_KEY = "postdogSidebarWidth";
 const DEFAULT_SIDEBAR_WIDTH = 230;
 const MIN_SIDEBAR_WIDTH = 180;
 const MAX_SIDEBAR_WIDTH = 520;
+const MAX_UPLOAD_FILE_BYTES = 5 * 1024 * 1024;
 
 export default function PostdogPanel() {
   const [folders, setFolders] = useState([]);
@@ -417,6 +418,15 @@ export default function PostdogPanel() {
     }
   }
 
+  function downloadResponseFile() {
+    const file = response?.response?.download;
+    if (!file?.dataBase64) {
+      toast.error("没有可下载的文件内容");
+      return;
+    }
+    downloadBase64(file.fileName, file.dataBase64, file.mimeType);
+  }
+
   function beautifyRequestJson() {
     try {
       setDraft({ ...draft, body: { ...draft.body, text: formatJsonWithComments(requestBodyText, 2) } });
@@ -512,12 +522,24 @@ export default function PostdogPanel() {
                       <option value="none">none</option>
                       <option value="json">json</option>
                       <option value="text">text</option>
+                      <option value="form">form</option>
+                      <option value="multipart">multipart</option>
                     </select>
                     {requestBodyType === "json" && (
                       <Button className="postdog-beautify-button !min-h-7 !px-2 !text-xs" onPress={beautifyRequestJson}>格式化 JSON</Button>
                     )}
                   </div>
-                  {requestBodyType === "json" ? (
+                  {requestBodyType === "form" ? (
+                    <KeyValueEditor
+                      rows={draft.body?.fields || []}
+                      onChange={fields => setDraft({ ...draft, body: { ...draft.body, fields } })}
+                    />
+                  ) : requestBodyType === "multipart" ? (
+                    <MultipartEditor
+                      rows={draft.body?.fields || []}
+                      onChange={fields => setDraft({ ...draft, body: { ...draft.body, fields } })}
+                    />
+                  ) : requestBodyType === "json" ? (
                     <JsonCodeEditor
                       value={requestBodyText}
                       onChange={text => setDraft({ ...draft, body: { ...draft.body, text } })}
@@ -614,7 +636,12 @@ export default function PostdogPanel() {
                 ) : responseTab === "headers" ? (
                   <HeaderTable headers={response.response.headers || {}} />
                 ) : response.response.bodyKind === "binary" ? (
-                  <div className="postdog-empty-response">{formatBinaryResponseMessage(response.response)}</div>
+                  <div className="postdog-file-response">
+                    <div>{formatBinaryResponseMessage(response.response)}</div>
+                    {response.response.download?.dataBase64 && (
+                      <Button className="!min-h-7 !px-2 !text-xs" onPress={downloadResponseFile}>下载文件</Button>
+                    )}
+                  </div>
                 ) : responseBodyJson?.ok ? (
                   <>
                     {response.response.bodyNote && <div className="postdog-body-note">{response.response.bodyNote}</div>}
@@ -778,6 +805,57 @@ function HeaderTable({ headers = {} }) {
   );
 }
 
+function MultipartEditor({ rows = [], onChange }) {
+  function update(index, patch) {
+    onChange(rows.map((row, i) => i === index ? { ...row, ...patch } : row));
+  }
+  function remove(index) {
+    onChange(rows.filter((_, i) => i !== index));
+  }
+  async function selectFile(index, file) {
+    if (!file) return;
+    if (file.size > MAX_UPLOAD_FILE_BYTES) {
+      toast.error("单个上传文件不能超过 5 MB");
+      return;
+    }
+    try {
+      update(index, {
+        kind: "file",
+        fileName: file.name,
+        mimeType: file.type || "application/octet-stream",
+        dataBase64: await fileToBase64(file),
+        value: ""
+      });
+    } catch (error) {
+      toast.error(error?.message || "读取文件失败");
+    }
+  }
+  return (
+    <div className="postdog-kv postdog-multipart">
+      {rows.map((row, index) => (
+        <div className="postdog-kv-row" key={index}>
+          <input title={row.key || ""} value={row.key || ""} onChange={e => update(index, { key: e.target.value })} placeholder="key" />
+          <select value={row.kind === "file" ? "file" : "text"} onChange={e => update(index, { kind: e.target.value, value: "", fileName: "", mimeType: "", dataBase64: "" })}>
+            <option value="text">Text</option>
+            <option value="file">File</option>
+          </select>
+          {row.kind === "file" ? (
+            <label className="postdog-file-picker">
+              <span title={row.fileName || ""}>{row.fileName || "选择文件"}</span>
+              <input type="file" onChange={e => selectFile(index, e.target.files?.[0])} />
+            </label>
+          ) : (
+            <input title={row.value || ""} value={row.value || ""} onChange={e => update(index, { value: e.target.value })} placeholder="value" />
+          )}
+          <label className="postdog-checkbox"><input type="checkbox" checked={row.enabled !== false} onChange={e => update(index, { enabled: e.target.checked })} />启用</label>
+          <button type="button" onClick={() => remove(index)}>×</button>
+        </div>
+      ))}
+      <button type="button" className="postdog-add-row" onClick={() => onChange([...rows, { key: "", value: "", kind: "text", enabled: true }])}>+ 添加</button>
+    </div>
+  );
+}
+
 function formatBinaryResponseMessage(response) {
   const contentType = response.headers?.["content-type"] || response.headers?.["Content-Type"] || "unknown";
   const size = formatResponseBytes(response.bodySizeBytes);
@@ -916,6 +994,35 @@ function downloadText(fileName, text, mimeType) {
   a.click();
   a.remove();
   setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function downloadBase64(fileName, dataBase64, mimeType) {
+  const binary = atob(dataBase64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+  const blob = new Blob([bytes], { type: mimeType || "application/octet-stream" });
+  downloadBlob(fileName || "download", blob);
+}
+
+function downloadBlob(fileName, blob) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName;
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function fileToBase64(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result || "").split(",")[1] || "");
+    reader.onerror = () => reject(reader.error || new Error("读取文件失败"));
+    reader.readAsDataURL(file);
+  });
 }
 
 function formatDate(date) {

--- a/src/component/postdog/postdog.css
+++ b/src/component/postdog/postdog.css
@@ -554,6 +554,39 @@
   font-size: 12px;
 }
 
+.postdog-file-response {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px;
+  color: #475569;
+  font-size: 12px;
+}
+
+.postdog-multipart .postdog-kv-row {
+  grid-template-columns: minmax(110px, 0.8fr) 76px minmax(160px, 1.4fr) auto 28px;
+}
+
+.postdog-file-picker {
+  min-width: 0;
+  cursor: pointer;
+}
+
+.postdog-file-picker span {
+  display: block;
+  overflow: hidden;
+  padding: 6px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.postdog-file-picker input {
+  display: none;
+}
+
 .postdog-body-editor {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Closes XIA-1

## Summary
- support URL-encoded form bodies with key/value fields
- support multipart text and file uploads
- preserve downloadable binary responses without storing payloads in history
- rely on Fetch's native gzip/deflate/br response decoding

## Verification
- Postdog tests: 15 passed
- production build: passed
- targeted ESLint: passed
- full suite: 278 passed, 1 unrelated existing settings backup failure