### PR TITLE
XIA-1: fix settings backup profile expectations

### DIFF
--- a/src/api/settings/backup.test.js
+++ b/src/api/settings/backup.test.js
@@ -182,6 +182,7 @@ describe("settings backup", () => {
             baseUrl: "https://opencode.ai/zen/v1/chat/completions",
             apiKey: "",
             model: "big-pickle",
+            nativeWebSearch: false,
             requiresApiKey: false
           },
           {
@@ -190,7 +191,8 @@ describe("settings backup", () => {
             apiType: "openai-responses",
             baseUrl: "https://new.example/v1/responses",
             apiKey: "new",
-            model: "new-model"
+            model: "new-model",
+            nativeWebSearch: false
           }
         ],
         modelContextLimitTokens: 200000,


### PR DESCRIPTION
Updates the settings backup import assertion for the normalized nativeWebSearch default added to LLM profiles.\n\nCloses XIA-1